### PR TITLE
Switch to port 80 outside the container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   sugar:
     build: .
     ports:
-      - "2999:2999"
+      - "2999:80"
     volumes:
       - node_modules:/node_app/node_modules
       - ./:/node_app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   sugar:
     build: .
     ports:
-      - "2999:80"
+      - "80:2999"
     volumes:
       - node_modules:/node_app/node_modules
       - ./:/node_app


### PR DESCRIPTION
My understanding is that this maps the external (host) port to the internal app port. This app is set up internally to use 2999, so I'd like to map that to the host's port 80. 