### PR TITLE
add sugar prod service lb

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -46,3 +46,16 @@ spec:
       port: 80
       targetPort: 80
   type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sugar-production-app-lb
+spec:
+  selector:
+    app: sugar-production-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: LoadBalancer


### PR DESCRIPTION
related to https://github.com/zooniverse/designator/pull/105

allow a service LB while the k8s ingress is down.