### PR TITLE
Use slim image and node 10 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11
+FROM node:10-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "request": "^2.88.0"
   },
   "engines": {
-    "node": "^11.10",
-    "npm": "^6.7"
+    "node": "^10.24",
+    "npm": "^6.14"
   },
   "scripts": {
     "start": "export NODE_ENV=development; ./node_modules/.bin/check-engines && ./node_modules/.bin/coffee index.coffee",


### PR DESCRIPTION
use even numbered LTS node releses instead of short lived odd numbered releases, https://nodejs.org/en/about/releases/
    
Sadly sugar currently only works on node < 12 due to a depenecy lock in setheader and to realize this change primus needs a major version bump which is a breaking change to the current system.