### PR TITLE
use GH container registry for k8s deploys

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: sugar-production-app
-          image: zooniverse/sugar:__IMAGE_TAG__
+          image: ghcr.io/zooniverse/sugar:__IMAGE_TAG__
           resources:
             requests:
               memory: "500Mi"

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: sugar-staging-app
-          image: zooniverse/sugar:__IMAGE_TAG__
+          image: ghcr.io/zooniverse/sugar:__IMAGE_TAG__
           resources:
             requests:
               memory: "100Mi"


### PR DESCRIPTION
switch the k8s templates to use the GHCR images instead of docker hub