### PR TITLE
Revert "Bump coffeescript from 2.3.2 to 2.7.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -467,9 +467,9 @@
       }
     },
     "coffeescript": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
-      "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.3.2.tgz",
+      "integrity": "sha512-YObiFDoukx7qPBi/K0kUKyntEZDfBQiqs/DbrR1xzASKOBjGT7auD85/DiPeRr9k++lRj7l3uA9TNMLfyfcD/Q==",
       "dev": true
     },
     "color": {


### PR DESCRIPTION
Reverts zooniverse/sugar#112

CoffeeScript 2.7 might break the `compile-client` script. 