### PR TITLE
Cache API responses for 60s

### DIFF
--- a/lib/cacheHeaders.js
+++ b/lib/cacheHeaders.js
@@ -1,0 +1,4 @@
+module.exports = function(req, res, next) {
+  res.header('Cache-Control', 's-maxage=60, stale-while-revalidate');
+  return next();
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,24 +1,14 @@
-var Panoptes, Presence, Primus, PubSub, basicAuth, bodyParser, cors, express, http, morgan;
-
-http = require('http');
-
-express = require('express');
-
-bodyParser = require('body-parser');
-
-morgan = require('morgan');
-
-Primus = require('primus');
-
-Panoptes = require('./panoptes');
-
-PubSub = require('./pub_sub');
-
-Presence = require('./presence');
-
-basicAuth = require('./basic_auth');
-
-cors = require('./cors');
+const http = require('http');
+const express = require('express');
+const bodyParser = require('body-parser');
+const morgan = require('morgan');
+const Primus = require('primus');
+const Panoptes = require('./panoptes');
+const PubSub = require('./pub_sub');
+const Presence = require('./presence');
+const basicAuth = require('./basic_auth');
+const cors = require('./cors');
+const cacheHeaders = require('./cacheHeaders')
 
 class Server {
   constructor() {
@@ -43,8 +33,8 @@ class Server {
     this._initializeApp();
     this._initializePrimus();
     this.app.get('/primus.js', this.primusAction);
-    this.app.get('/presence', this.presenceAction);
-    this.app.get('/active_users', this.activeUsersAction);
+    this.app.get('/presence', cacheHeaders, this.presenceAction);
+    this.app.get('/active_users', cacheHeaders, this.activeUsersAction);
     this.app.post('/notify', basicAuth, this.notifyAction);
     this.app.post('/announce', basicAuth, this.announceAction);
     this.app.post('/experiment', basicAuth, this.experimentAction);


### PR DESCRIPTION
Set `Cache-Control: s-maxage=60, stale-while-revalidate` on the `/presence` and `/active_users` endpoints.