### PR TITLE
Cache with max-age and s-maxage

### DIFF
--- a/lib/cacheHeaders.js
+++ b/lib/cacheHeaders.js
@@ -1,4 +1,4 @@
 module.exports = function(req, res, next) {
-  res.header('Cache-Control', 's-maxage=60, stale-while-revalidate');
+  res.header('Cache-Control', 'maxage=60, s-maxage=30, stale-while-revalidate');
   return next();
 };


### PR DESCRIPTION
Specify `maxage` (browser caches) and `s-maxage` (shared caches) in API response headers for GET requests.