### PR TITLE
Bump redis from 3.1.1 to 4.6.4

### DIFF
--- a/lib/presence.js
+++ b/lib/presence.js
@@ -15,6 +15,7 @@ class Presence {
     this.__scan = this.__scan.bind(this);
     this._scanner = this._scanner.bind(this);
     this.redis = new RedisClient();
+    this.redis.connect();
     setInterval(this.clearInactive, 1 * 60 * 1000); // Clear inactive every minute
   }
 
@@ -22,20 +23,20 @@ class Presence {
     if (this._isUserChannel(channel)) {
       return Promise.resolve();
     }
-    return this.redis.zaddAsync(`presence:${channel}`, +new Date(), userKey);
+    return this.redis.zAdd(`presence:${channel}`, { score: +new Date(), value: userKey });
   }
 
   userInactiveOn(channel, userKey) {
     if (this._isUserChannel(channel)) {
       return Promise.resolve();
     }
-    return this.redis.zremAsync(`presence:${channel}`, userKey);
+    return this.redis.zRem(`presence:${channel}`, userKey);
   }
 
   async clearInactive() {
     const twoMinutesAgo = (+new Date()) - 120000;
     const channels = await this.channels();
-    const promises = channels.map(channel => this.redis.zremrangebyscoreAsync(`presence:${channel}`, '-inf', twoMinutesAgo));
+    const promises = channels.map(channel => this.redis.zRemRangeByScore(`presence:${channel}`, '-inf', twoMinutesAgo));
     return Promise.all(promises);
   }
 
@@ -59,7 +60,7 @@ class Presence {
   }
 
   countOn(channel) {
-    return this.redis.zcardAsync(`presence:${channel}`);
+    return this.redis.zCard(`presence:${channel}`);
   }
 
   async usersOn(channel) {
@@ -67,9 +68,9 @@ class Presence {
       key: `presence:${channel}`,
       pattern: 'user:*'
     });
-    return values
-      .filter((key, i) => i % 2 === 0)
-      .map(key => key.replace(/^user:/, ''));
+    return values.map(function({ value, score }) {
+      return value.replace(/^user:/, '');
+    });
   }
 
   _scan(opts = {}) {
@@ -82,21 +83,21 @@ class Presence {
 
   async __scan(opts) {
     const values = await this._scanner(opts);
-    opts.results = opts.results.concat(values[1]);
-    if (values[0] === '0') {
+    const results = values.keys || values.members;
+    opts.results = opts.results.concat(results);
+    if (values.cursor === 0) {
       return Promise.resolve(opts.results);
     } else {
-      opts.cursor = values[0];
+      opts.cursor = values.cursor;
       return this.__scan(opts);
     }
   }
 
   _scanner(opts) {
     if (opts.key) {
-      return this.redis.zscanAsync(opts.key, opts.cursor, 'match', opts.pattern);
-    } else {
-      return this.redis.scanAsync(opts.cursor, 'match', opts.pattern);
+      return this.redis.zScan(opts.key, opts.cursor, { MATCH: opts.pattern });
     }
+    return this.redis.scan(opts.cursor, { MATCH: opts.pattern });
   }
 
   _isUserChannel(channel) {

--- a/lib/pub_sub.js
+++ b/lib/pub_sub.js
@@ -10,12 +10,8 @@ class PubSub {
     this.unsubscribe = this.unsubscribe.bind(this);
     this.publish = this.publish.bind(this);
     this.emitter = new Events.EventEmitter();
-    this.redis = {
-      pub: new RedisClient(),
-      sub: new RedisClient()
-    };
-    this.redis.sub.on('message', this.emitMessage);
-    this.redis.sub.on('pmessage', this.emitMessage);
+    this.publisher = new RedisClient();
+    this.subscriber = new RedisClient();
   }
 
   emitMessage(pattern, channel, message) {
@@ -23,29 +19,39 @@ class PubSub {
   }
 
   async subscribe(pattern, fn) {
+    if (!this.subscriber.isOpen) {
+      await this.subscriber.connect();
+    }
     const isPattern = pattern.match(/\*|\[|\]|\?/);
+    const handler = (message, channel) => this.emitMessage(pattern, channel, message);
     if (isPattern) {
-      await this.redis.sub.psubscribeAsync(pattern);
+      await this.subscriber.pSubscribe(pattern, handler);
     } else {
-      await this.redis.sub.subscribeAsync(pattern);
+      await this.subscriber.subscribe(pattern, handler);
     }
     this.emitter.on(pattern, fn);
   }
 
-  unsubscribe(pattern, fn) {
+  async unsubscribe(pattern, fn) {
+    if (!this.subscriber.isOpen) {
+      await this.subscriber.connect();
+    }
     this.emitter.removeListener(pattern, fn);
     const listeners = this.emitter.listenerCount(pattern);
     if (listeners === 0) {
       const isPattern = pattern.match(/\*|\[|\]|\?/);
       if (isPattern) {
-        return this.redis.sub.punsubscribeAsync(pattern);
+        return this.subscriber.pUnsubscribe(pattern);
       }
-      return this.redis.sub.unsubscribeAsync(pattern);
+      return this.subscriber.unsubscribe(pattern);
     }
   }
 
-  publish(channel, message) {
-    return this.redis.pub.publishAsync(channel, JSON.stringify(message));
+  async publish(channel, message) {
+    if (!this.publisher.isOpen) {
+      await this.publisher.connect();
+    }
+    return this.publisher.publish(channel, JSON.stringify(message));
   }
 
 };

--- a/lib/redis_client.js
+++ b/lib/redis_client.js
@@ -1,48 +1,28 @@
 var Redis = require('redis');
 var Sentry = require('@sentry/node');
 
-const { promisify } = require('util');
-
-const redisCommands = [
-  'exists',
-  'flushall',
-  'publish',
-  'subscribe',
-  'psubscribe',
-  'unsubscribe',
-  'punsubscribe',
-  'zadd',
-  'zrem',
-  'zrangebyscore',
-  'zremrangebyscore',
-  'zcard',
-  'scan',
-  'zscan'
-];
-
 class RedisClient {
   constructor() {
-    var auth, auth_opts, client, db, host, port;
-    port = process.env.SUGAR_REDIS_PORT;
-    port || (port = 6379);
-    host = process.env.SUGAR_REDIS_HOST;
-    host || (host = '127.0.0.1');
-    auth = process.env.SUGAR_REDIS_AUTH;
-    db = process.env.SUGAR_REDIS_DB || 1;
+    const port = process.env.SUGAR_REDIS_PORT || 6379;
+    const host = process.env.SUGAR_REDIS_HOST || '127.0.0.1';
+    const auth = process.env.SUGAR_REDIS_AUTH;
+    const db = process.env.SUGAR_REDIS_DB || 1;
     // redis in test / dev doesn't have a TLS proxy in front of it
-    auth_opts = process.env.SUGAR_REDIS_NO_TLS ? {} : {
-      auth_pass: auth,
-      tls: {
-        servername: host
-      }
+    const tls_opts = process.env.SUGAR_REDIS_NO_TLS ? {} : {
+      tls: true,
+      servername: host
     };
-    client = Redis.createClient(port, host, auth_opts);
+    const client = Redis.createClient({
+      database: db,
+      socket: {
+        host,
+        port,
+        ...tls_opts
+      },
+      password: auth
+    });
     client.on('error', function (error) {
       Sentry.captureException(error);
-    });
-    client.select(db);
-    redisCommands.forEach(command => {
-      client[`${command}Async`] = promisify(client[command]);
     });
     return client;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "morgan": "^1.9.1",
         "newrelic": "^9.7.5",
         "primus": "^8.0.7",
-        "redis": "^3.0.2",
+        "redis": "^4.6.4",
         "request": "^2.88.2"
       },
       "devDependencies": {
@@ -190,6 +190,64 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.5.tgz",
+      "integrity": "sha512-fuMnpDYSjT5JXR9rrCW1YWA4L8N/9/uS4ImT3ZEC/hcaQRI1D/9FvwjriRj1UvepIgzZXthFVKMNRzP/LNL7BQ==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.0.tgz",
+      "integrity": "sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+      "integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.1.tgz",
+      "integrity": "sha512-pqCXTc5e7wJJgUuJiC3hBgfoFRoPxYzwn0BEfKgejTM7M/9zP3IpUcqcjgfp8hF+LoV8rHZzcNTz7V+pEIY7LQ==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.4.tgz",
+      "integrity": "sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
     },
     "node_modules/@sentry/core": {
       "version": "7.37.1",
@@ -816,6 +874,14 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
@@ -1057,14 +1123,6 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/denque": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
-      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -1619,6 +1677,14 @@
       "dependencies": {
         "emits": "3.0.x",
         "predefine": "0.1.x"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-caller-file": {
@@ -2750,45 +2816,16 @@
       }
     },
     "node_modules/redis": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.1.tgz",
-      "integrity": "sha512-QhkKhOuzhogR1NDJfBD34TQJz2ZJwDhhIC6ZmvpftlmfYShHHQXjjNspAJ+Z2HH5NwSBVYBVganbiZ8bgFMHjg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.6.4.tgz",
+      "integrity": "sha512-wi2tgDdQ+Q8q+PR5FLRx4QvDiWaA+PoJbrzsyFqlClN5R4LplHqN3scs/aGjE//mbz++W19SgxiEnQ27jnCRaA==",
       "dependencies": {
-        "denque": "^1.5.0",
-        "redis-commands": "^1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-redis"
-      }
-    },
-    "node_modules/redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-    },
-    "node_modules/redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
-      "dependencies": {
-        "redis-errors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.5.5",
+        "@redis/graph": "1.1.0",
+        "@redis/json": "1.0.4",
+        "@redis/search": "1.1.1",
+        "@redis/time-series": "1.0.4"
       }
     },
     "node_modules/request": {
@@ -3672,6 +3709,53 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "requires": {}
+    },
+    "@redis/client": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.5.tgz",
+      "integrity": "sha512-fuMnpDYSjT5JXR9rrCW1YWA4L8N/9/uS4ImT3ZEC/hcaQRI1D/9FvwjriRj1UvepIgzZXthFVKMNRzP/LNL7BQ==",
+      "requires": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "@redis/graph": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.0.tgz",
+      "integrity": "sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==",
+      "requires": {}
+    },
+    "@redis/json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+      "integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+      "requires": {}
+    },
+    "@redis/search": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.1.tgz",
+      "integrity": "sha512-pqCXTc5e7wJJgUuJiC3hBgfoFRoPxYzwn0BEfKgejTM7M/9zP3IpUcqcjgfp8hF+LoV8rHZzcNTz7V+pEIY7LQ==",
+      "requires": {}
+    },
+    "@redis/time-series": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.4.tgz",
+      "integrity": "sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==",
+      "requires": {}
+    },
     "@sentry/core": {
       "version": "7.37.1",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.37.1.tgz",
@@ -4168,6 +4252,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
+    },
     "color": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
@@ -4364,11 +4453,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-    },
-    "denque": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
-      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -4799,6 +4883,11 @@
         "emits": "3.0.x",
         "predefine": "0.1.x"
       }
+    },
+    "generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -5678,32 +5767,16 @@
       }
     },
     "redis": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.1.tgz",
-      "integrity": "sha512-QhkKhOuzhogR1NDJfBD34TQJz2ZJwDhhIC6ZmvpftlmfYShHHQXjjNspAJ+Z2HH5NwSBVYBVganbiZ8bgFMHjg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.6.4.tgz",
+      "integrity": "sha512-wi2tgDdQ+Q8q+PR5FLRx4QvDiWaA+PoJbrzsyFqlClN5R4LplHqN3scs/aGjE//mbz++W19SgxiEnQ27jnCRaA==",
       "requires": {
-        "denque": "^1.5.0",
-        "redis-commands": "^1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0"
-      }
-    },
-    "redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-    },
-    "redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
-    },
-    "redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
-      "requires": {
-        "redis-errors": "^1.0.0"
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.5.5",
+        "@redis/graph": "1.1.0",
+        "@redis/json": "1.0.4",
+        "@redis/search": "1.1.1",
+        "@redis/time-series": "1.0.4"
       }
     },
     "request": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "morgan": "^1.9.1",
     "newrelic": "^9.7.5",
     "primus": "^8.0.7",
-    "redis": "^3.0.2",
+    "redis": "^4.6.4",
     "request": "^2.88.2"
   },
   "engines": {

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ process.env.PANOPTES_HOST = 'http://sugar_test.panoptes';
 RedisClient = require('../lib/redis_client');
 
 redis = new RedisClient();
+redis.connect();
 
 PanoptesServer = require('./support/panoptes_server');
 
@@ -43,5 +44,5 @@ nock.disableNetConnect();
 nock.enableNetConnect('localhost');
 
 beforeEach(function() {
-  return redis.flushallAsync();
+  return redis.flushAll();
 });

--- a/test/pub_sub.js
+++ b/test/pub_sub.js
@@ -28,24 +28,24 @@ describe('PubSub', function() {
     });
   };
   describe('#subscribe', function() {
-    it('should subscribe to a pubsub channel', function() {
-      pubSub.redis.sub.subscribeAsync = chai.spy(thennableSpy);
-      return subscribeTo('test').then(function() {
-        return expect(pubSub.redis.sub.subscribeAsync).to.have.been.called.once.with('test');
-      });
+    it('should subscribe to a pubsub channel', async function() {
+      const subscriber = pubSub.subscriber;
+      subscriber.subscribe = chai.spy(thennableSpy);
+      await subscribeTo('test');
+      expect(subscriber.subscribe).to.have.been.called.once.with('test');
     });
-    it('should subscribe to a pubsub pattern', function() {
-      pubSub.redis.sub.psubscribeAsync = chai.spy(thennableSpy);
-      return subscribeTo('test:*').then(function() {
-        return expect(pubSub.redis.sub.psubscribeAsync).to.have.been.called.once.with('test:*');
-      });
+    it('should subscribe to a pubsub pattern', async function() {
+      const subscriber = pubSub.subscriber;
+      subscriber.pSubscribe = chai.spy(thennableSpy);
+      await subscribeTo('test:*');
+      expect(subscriber.pSubscribe).to.have.been.called.once.with('test:*');
     });
     it('should add a listener to a single channel', function() {
       var fn;
       pubSub.emitter.on = chai.spy(thennableSpy);
       fn = function() {};
       return pubSub.subscribe('test', fn).then(function() {
-        return expect(pubSub.emitter.on).to.have.been.called.once.with('test', fn);
+        expect(pubSub.emitter.on).to.have.been.called.once.with('test', fn);
       });
     });
     return it('should add a listener to a pattern', function() {
@@ -53,58 +53,61 @@ describe('PubSub', function() {
       pubSub.emitter.on = chai.spy(thennableSpy);
       fn = function() {};
       return pubSub.subscribe('test:*', fn).then(function() {
-        return expect(pubSub.emitter.on).to.have.been.called.once.with('test:*', fn);
+        expect(pubSub.emitter.on).to.have.been.called.once.with('test:*', fn);
       });
     });
   });
   describe('#unsubscribe', function() {
     it('should unsubscribe from a pubsub channel', function() {
       return subscribeTo('test').then(function(fn) {
-        pubSub.redis.sub.unsubscribeAsync = chai.spy(thennableSpy);
+        const subscriber = pubSub.subscriber;
+        subscriber.unsubscribe = chai.spy(thennableSpy);
         pubSub.unsubscribe('test', fn);
-        return expect(pubSub.redis.sub.unsubscribeAsync).to.have.been.called.once.with('test');
+        expect(subscriber.unsubscribe).to.have.been.called.once.with('test');
       });
     });
     it('should unsubscribe from a pubsub pattern', function() {
       return subscribeTo('test:*').then(function(fn) {
-        pubSub.redis.sub.punsubscribeAsync = chai.spy(thennableSpy);
+        const subscriber = pubSub.subscriber;
+        subscriber.pUnsubscribe = chai.spy(thennableSpy);
         pubSub.unsubscribe('test:*', fn);
-        return expect(pubSub.redis.sub.punsubscribeAsync).to.have.been.called.once.with('test:*');
+        expect(subscriber.pUnsubscribe).to.have.been.called.once.with('test:*');
       });
     });
     it('should remove a listener from a single channel', function() {
       return subscribeTo('test').then(function(fn) {
         pubSub.emitter.removeListener = chai.spy(thennableSpy);
         pubSub.unsubscribe('test', fn);
-        return expect(pubSub.emitter.removeListener).to.have.been.called.once.with('test', fn);
+        expect(pubSub.emitter.removeListener).to.have.been.called.once.with('test', fn);
       });
     });
     it('should remove a listener from a pattern', function() {
       return subscribeTo('test:*').then(function(fn) {
         pubSub.emitter.removeListener = chai.spy(thennableSpy);
         pubSub.unsubscribe('test:*', fn);
-        return expect(pubSub.emitter.removeListener).to.have.been.called.once.with('test:*', fn);
+        expect(pubSub.emitter.removeListener).to.have.been.called.once.with('test:*', fn);
       });
     });
     return it('should only unsubscribe from redis when no subscribers remain', function() {
       return Promise.all([subscribeTo('test'), subscribeTo('test')]).then(function(callbacks) {
+        const subscriber = pubSub.subscriber;
         var fn1, fn2;
         [fn1, fn2] = callbacks;
-        pubSub.redis.sub.unsubscribeAsync = chai.spy(thennableSpy);
+        subscriber.unsubscribe = chai.spy(thennableSpy);
         pubSub.unsubscribe('test', fn1);
-        expect(pubSub.redis.sub.unsubscribeAsync).to.not.have.been.called();
+        expect(subscriber.unsubscribe).to.not.have.been.called();
         pubSub.unsubscribe('test', fn2);
-        return expect(pubSub.redis.sub.unsubscribeAsync).to.have.been.called();
+        expect(subscriber.unsubscribe).to.have.been.called();
       });
     });
   });
   describe('#publish', function() {
     return it('should publish a messsage to a channel', function() {
-      pubSub.redis.pub.publishAsync = chai.spy(thennableSpy);
+      pubSub.publisher.publish = chai.spy(thennableSpy);
       return pubSub.publish('test', {
         works: true
       }).then(function() {
-        return expect(pubSub.redis.pub.publishAsync).to.have.been.called.once.with('test', '{"works":true}');
+        return expect(pubSub.publisher.publish).to.have.been.called.once.with('test', '{"works":true}');
       });
     });
   });


### PR DESCRIPTION
Bump Node Redis to 4.6.4 and update the client to use the v4 API.

This is a redo of #133, with the latest version of Node Redis and the client code [updated to the v4 API](https://github.com/redis/node-redis/blob/master/docs/v3-to-v4.md).