### PR TITLE
Fix Sentry middlewares

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -39,6 +39,11 @@ class Server {
     this.app.post('/notify', basicAuth, this.notifyAction);
     this.app.post('/announce', basicAuth, this.announceAction);
     this.app.post('/experiment', basicAuth, this.experimentAction);
+    this.app.use(Sentry.Handlers.errorHandler());
+    this.app.use(function onError(error, req, res, next) {
+      res.statusCode=500;
+      res.end(res.sentry + "\n");
+    });
   }
 
   close() {
@@ -47,11 +52,10 @@ class Server {
 
   _initializeApp() {
     this.app = express();
+    this.app.use(Sentry.Handlers.requestHandler());
     if (!process.env.SUGAR_TEST) {
       this.app.use(morgan('dev'));
     }
-    this.app.use(Sentry.Handlers.requestHandler());
-    this.app.use(Sentry.Handlers.errorHandler());
     this.app.use(cors);
     this.app.use(bodyParser.json());
     this.app.use(bodyParser.urlencoded({


### PR DESCRIPTION
The request handler must be the first middleware. The error handler must be added after all the controllers. https://docs.sentry.io/platforms/node/guides/express/