### PR TITLE
Rate limit the API POST endpoints

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/node');
 const http = require('http');
 const express = require('express');
+const rateLimit = require('express-rate-limit')
 const bodyParser = require('body-parser');
 const morgan = require('morgan');
 const Primus = require('primus');
@@ -13,6 +14,12 @@ const cacheHeaders = require('./cacheHeaders')
 
 class Server {
   constructor() {
+    const limiter = rateLimit({
+    	windowMs: 15 * 60 * 1000, // 15 minutes
+    	max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
+    	standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    	legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+    })
     this.close = this.close.bind(this);
     this.authenticate = this.authenticate.bind(this);
     this.authorize = this.authorize.bind(this);
@@ -36,9 +43,9 @@ class Server {
     this.app.get('/primus.js', this.primusAction);
     this.app.get('/presence', cacheHeaders, this.presenceAction);
     this.app.get('/active_users', cacheHeaders, this.activeUsersAction);
-    this.app.post('/notify', basicAuth, this.notifyAction);
-    this.app.post('/announce', basicAuth, this.announceAction);
-    this.app.post('/experiment', basicAuth, this.experimentAction);
+    this.app.post('/notify', limiter, basicAuth, this.notifyAction);
+    this.app.post('/announce', limiter, basicAuth, this.announceAction);
+    this.app.post('/experiment', limiter, basicAuth, this.experimentAction);
     this.app.use(Sentry.Handlers.errorHandler());
     this.app.use(function onError(error, req, res, next) {
       console.error(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "check-engines": "^1.5.0",
         "engine.io": "^6.3.1",
         "express": "^4.16.4",
+        "express-rate-limit": "^6.7.0",
         "jsonwebtoken": "^9.0.0",
         "morgan": "^1.9.1",
         "newrelic": "^10.0.0",
@@ -1379,6 +1380,17 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
+      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
+      "engines": {
+        "node": ">= 12.9.0"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
       }
     },
     "node_modules/express/node_modules/accepts": {
@@ -4518,6 +4530,12 @@
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
+    },
+    "express-rate-limit": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
+      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
+      "requires": {}
     },
     "extendible": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "check-engines": "^1.5.0",
     "engine.io": "^6.3.1",
     "express": "^4.16.4",
+    "express-rate-limit": "^6.7.0",
     "jsonwebtoken": "^9.0.0",
     "morgan": "^1.9.1",
     "newrelic": "^10.0.0",


### PR DESCRIPTION
Limit requests to 100 per 15 minutes, with `Retry-After` headers on failed requests.